### PR TITLE
boilerplate comments removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ spec:
 
 ### Notebook API
 
-The Notebook API allows data scientists to quickly spin up a Jupyter Notebook from an existing Model to allow for quick iteration. 
+The Notebook API allows data scientists to quickly spin up a Jupyter Notebook from an existing Model to allow for quick iteration.
 
 Notebooks can be opened using the `kubectl open notebook` command (which is a substratus kubectl plugin).
 

--- a/api/v1/dataset_types.go
+++ b/api/v1/dataset_types.go
@@ -5,17 +5,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // DatasetSpec defines the desired state of Dataset
 type DatasetSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	Source DatasetSource `json:"source,omitempty"`
-
-	Size resource.Quantity `json:"size"`
+	Source DatasetSource     `json:"source,omitempty"`
+	Size   resource.Quantity `json:"size"`
 }
 
 type DatasetSource struct {
@@ -26,10 +19,7 @@ type DatasetSource struct {
 
 // DatasetStatus defines the observed state of Dataset
 type DatasetStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-	PVCName string `json:"pvcName,omitempty"`
-
+	PVCName    string             `json:"pvcName,omitempty"`
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/v1/model_types.go
+++ b/api/v1/model_types.go
@@ -4,19 +4,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // ModelSpec defines the desired state of Model
 type ModelSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=latest
-	Version string `json:"version,omitempty"`
-
+	Version  string      `json:"version,omitempty"`
 	Source   ModelSource `json:"source"`
 	Training *Training   `json:"training,omitempty"`
-
-	Size ModelSize `json:"size,omitempty"`
+	Size     ModelSize   `json:"size,omitempty"`
 }
 
 type ModelSize struct {
@@ -31,7 +26,6 @@ type Training struct {
 type ModelSource struct {
 	Git       *GitSource `json:"git,omitempty"`
 	ModelName string     `json:"modelName,omitempty"`
-
 	// TODO:
 	//Container
 }
@@ -63,8 +57,6 @@ type GitSource struct {
 
 // ModelStatus defines the observed state of Model
 type ModelStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
 	ContainerImage string             `json:"containerImage,omitempty"`
 	Conditions     []metav1.Condition `json:"conditions,omitempty"`
 	Servers        []string           `json:"servers,omitempty"`

--- a/api/v1/modelserver_types.go
+++ b/api/v1/modelserver_types.go
@@ -4,23 +4,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // ModelServerSpec defines the desired state of ModelServer
 type ModelServerSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	// Foo is an example field of ModelServer. Edit modelserver_types.go to remove/update
 	ModelName string `json:"modelName,omitempty"`
 }
 
 // ModelServerStatus defines the observed state of ModelServer
 type ModelServerStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/v1/notebook_types.go
+++ b/api/v1/notebook_types.go
@@ -4,18 +4,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // NotebookSpec defines the desired state of Notebook
 type NotebookSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	// Foo is an example field of Notebook. Edit notebook_types.go to remove/update
 	ModelName string `json:"modelName,omitempty"`
-
-	Suspend bool `json:"suspend,omitempty"`
+	Suspend   bool   `json:"suspend,omitempty"`
 }
 
 // NotebookStatus defines the observed state of Notebook

--- a/internal/controller/dataset_controller.go
+++ b/internal/controller/dataset_controller.go
@@ -37,15 +37,6 @@ type DatasetReconciler struct {
 //+kubebuilder:rbac:groups=substratus.ai,resources=datasets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=substratus.ai,resources=datasets/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Dataset object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.4/pkg/reconcile
 func (r *DatasetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	lg := log.FromContext(ctx)
 

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -48,15 +48,6 @@ type ModelReconcilerConfig struct {
 //+kubebuilder:rbac:groups=substratus.ai,resources=models/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=substratus.ai,resources=models/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Model object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.4/pkg/reconcile
 func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	lg := log.FromContext(ctx)
 

--- a/internal/controller/modelserver_controller.go
+++ b/internal/controller/modelserver_controller.go
@@ -37,15 +37,6 @@ type ModelServerReconciler struct {
 //+kubebuilder:rbac:groups=substratus.ai,resources=modelservers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=substratus.ai,resources=modelservers/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the ModelServer object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.4/pkg/reconcile
 func (r *ModelServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	lg := log.FromContext(ctx)
 

--- a/internal/controller/notebook_controller.go
+++ b/internal/controller/notebook_controller.go
@@ -33,15 +33,6 @@ type NotebookReconciler struct {
 //+kubebuilder:rbac:groups=substratus.ai,resources=notebooks/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=substratus.ai,resources=notebooks/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Notebook object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.4/pkg/reconcile
 func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	lg := log.FromContext(ctx)
 


### PR DESCRIPTION
## What is this change?

Removes the kubebuilder boilerplate comments.

## Why make this change?

Boilerplate comments are useful the first time you use kubebuilder... and then they're just in the way.