### PR TITLE
Update falcon-7b-instruct to point to git repo

### DIFF
--- a/examples/falcon-7b-instruct/model.yaml
+++ b/examples/falcon-7b-instruct/model.yaml
@@ -5,8 +5,7 @@ metadata:
 spec:
   source:
     git:
-      url: github.com/substratusai/models
-      path: falcon-7b-instruct
+      url: github.com/substratusai/model-falcon-7b-instruct
   size:
     parameterBits: 16
     parameterCount: 7000000000


### PR DESCRIPTION
Using the new location where each model will have it's own repo