### PR TITLE
making docker tags immutable on our registry

### DIFF
--- a/install/terraform/gcp/registry.tf
+++ b/install/terraform/gcp/registry.tf
@@ -4,5 +4,8 @@ resource "google_artifact_registry_repository" "main" {
   repository_id = var.name
   description   = "Substratus Docker Registry"
   format        = "DOCKER"
-  depends_on    = [google_project_service.main]
+  docker_config {
+    immutable_tags = true
+  }
+  depends_on = [google_project_service.main]
 }


### PR DESCRIPTION
This must be a newer feature but one worth enforcing on our artifact registry repo.