### PR TITLE
remove ephemeral storage limit

### DIFF
--- a/install/terraform/gcp/node_pools_cpu.tf
+++ b/install/terraform/gcp/node_pools_cpu.tf
@@ -13,7 +13,7 @@ resource "google_container_node_pool" "builder_1" {
   node_config {
     machine_type = "n2d-standard-8"
     ephemeral_storage_local_ssd_config {
-      local_ssd_count = 1
+      local_ssd_count = 2
     }
   }
 

--- a/internal/controller/runtime.go
+++ b/internal/controller/runtime.go
@@ -148,20 +148,19 @@ func setRuntimeResources(model *apiv1.Model, spec *corev1.PodSpec, gpuType GPUTy
 	case RuntimeNotebook:
 		// Model is already stored in the container.
 		// Ephemeral storage is just needed for what the user downloads.
-		ephStorage = 10 * gigabyte
+		ephStorage = 100 * gigabyte
 	case RuntimeTrainer:
 		// Model artifacts are stored using volumes outside of container.
-		ephStorage = 10 * gigabyte
+		ephStorage = 100 * gigabyte
 	case RuntimeBuilder:
 		// Use 2x the model size because kaniko takes snapshots
 		// Add a fixed cushion.
-		ephStorage = int64(2*float64(modelBytes)) + 40*gigabyte
+		ephStorage = int64(2*float64(modelBytes)) + 100*gigabyte
 	case RuntimeServer:
 		// Model is already stored in the container. Server should need minimal ephemeral storage.
-		ephStorage = 10 * gigabyte
+		ephStorage = 100 * gigabyte
 	}
 	resources.Requests[corev1.ResourceEphemeralStorage] = *resource.NewQuantity(roundUpGB(ephStorage), resource.BinarySI)
-	resources.Limits[corev1.ResourceEphemeralStorage] = *resource.NewQuantity(roundUpGB(ephStorage), resource.BinarySI)
 
 	setRes := func(i int, containers []corev1.Container) {
 		if containers[i].Resources.Requests == nil {

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -36,11 +36,10 @@ containers:
 - name: trainer
   resources:
     limits:
-      ephemeral-storage: 10Gi
       nvidia.com/gpu: "1"
     requests:
       cpu: "2"
-      ephemeral-storage: 10Gi
+      ephemeral-storage: 100Gi
       memory: 3Gi
       nvidia.com/gpu: "1"
 nodeSelector:
@@ -57,11 +56,10 @@ containers:
 - name: notebook
   resources:
     limits:
-      ephemeral-storage: 10Gi
       nvidia.com/gpu: "1"
     requests:
       cpu: "2"
-      ephemeral-storage: 10Gi
+      ephemeral-storage: 100Gi
       memory: 3Gi
       nvidia.com/gpu: "1"
 nodeSelector:
@@ -78,11 +76,10 @@ containers:
 - name: server
   resources:
     limits:
-      ephemeral-storage: 10Gi
       nvidia.com/gpu: "1"
     requests:
       cpu: "2"
-      ephemeral-storage: 10Gi
+      ephemeral-storage: 100Gi
       memory: 3Gi
       nvidia.com/gpu: "1"
 nodeSelector:
@@ -98,11 +95,9 @@ tolerations:
 containers:
 - name: builder
   resources:
-    limits:
-      ephemeral-storage: 41Gi
     requests:
       cpu: "2"
-      ephemeral-storage: 41Gi
+      ephemeral-storage: 101Gi
       memory: 12Gi
 				`,
 			},
@@ -123,11 +118,10 @@ containers:
 - name: trainer
   resources:
     limits:
-      ephemeral-storage: 10Gi
       nvidia.com/gpu: "1"
     requests:
       cpu: "2"
-      ephemeral-storage: 10Gi
+      ephemeral-storage: 100Gi
       memory: 17Gi
       nvidia.com/gpu: "1"
 nodeSelector:
@@ -144,11 +138,10 @@ containers:
 - name: notebook
   resources:
     limits:
-      ephemeral-storage: 10Gi
       nvidia.com/gpu: "1"
     requests:
       cpu: "2"
-      ephemeral-storage: 10Gi
+      ephemeral-storage: 100Gi
       memory: 17Gi
       nvidia.com/gpu: "1"
 nodeSelector:
@@ -165,11 +158,10 @@ containers:
 - name: server
   resources:
     limits:
-      ephemeral-storage: 10Gi
       nvidia.com/gpu: "1"
     requests:
       cpu: "2"
-      ephemeral-storage: 10Gi
+      ephemeral-storage: 100Gi
       memory: 17Gi
       nvidia.com/gpu: "1"
 nodeSelector:
@@ -185,11 +177,9 @@ tolerations:
 containers:
 - name: builder
   resources:
-    limits:
-      ephemeral-storage: 67Gi
     requests:
       cpu: "2"
-      ephemeral-storage: 67Gi
+      ephemeral-storage: 127Gi
       memory: 12Gi
 				`,
 			},


### PR DESCRIPTION
During model development I frequently hit out of ephemeral storage limit errors so it's better to only set the request instead of also setting a limit. This way if there was more eph storage available it would at least still succeed.

In addition, I've slightly increased the requests to ensure there is always plenty ephemeral storage available. We rather error on slightly overprovisioning than causing failure of building job