### PR TITLE
scale GKE builder nodepool to 0

### DIFF
--- a/install/terraform/gcp/node_pools_cpu.tf
+++ b/install/terraform/gcp/node_pools_cpu.tf
@@ -1,27 +1,3 @@
-resource "google_container_node_pool" "system" {
-  # this nodepool runs services like kube-dns
-  name = "system"
-
-  cluster            = google_container_cluster.main.id
-  initial_node_count = 2
-
-  autoscaling {
-    min_node_count = 1
-    max_node_count = 5
-  }
-
-  node_config {
-    machine_type = "e2-medium"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      initial_node_count
-    ]
-  }
-}
-
-
 resource "google_container_node_pool" "builder_1" {
   name = "builder-1"
 


### PR DESCRIPTION
* Change builder nodepool to use spot VMs (will make this configurable for CPU and GPU nodepools at some point)
* Make the builder nodepool multizonal to reduce likelihood of stockout 
* set min scale of builder nodepool to 0